### PR TITLE
misc fixes

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -51,14 +51,14 @@
     {
       "name": "default-build-linux",
       "displayName": "Default",
-      "configurePreset": "x64-debug",
+      "configurePreset": "linux-x64-debug",
       "description": "Vanilla build"
     },
     {
       "name": "verbose-build-linux",
       "displayName": "Verbose Build",
       "description": "Passes -v to Ninja",
-      "configurePreset": "x64-debug",
+      "configurePreset": "linux-x64-debug",
       "nativeToolOptions": [ "-v" ]
     }
   ]

--- a/double.cu
+++ b/double.cu
@@ -33,6 +33,7 @@ thrust::device_event Double(thrust::host_vector<T>& ts) {
   // デバイスからホストへの非同期コピー
   auto copy_back_ts_event = thrust::async::copy(
       thrust::device.after(double_ts_event),
+      thrust::host,
       device_ts.begin(),
       device_ts.end(),
       ts.begin()


### PR DESCRIPTION
手元で試してみたらうまく動かなかったので以下の修正を行いました(最新コミットではOSSではなくなったので改変の自由が存在するかわかりませんが):

- `CMakePresets.json` の `configurePreset` を定義されているものに修正
    - 現状だと `cmake --preset 何か` したときに以下のエラーメッセージが出る
      
      ```
      CMake Error: Could not read presets from /home/user/src/ThrustAsyncProgram:
      Invalid "configurePreset": "default-build-linux"
      ```
- device to hostの `thrust::async::copy` のto policyに `thrust::host` を指定
    - して良いのかわからなかったのですが，しないと `cudaErrorInvalidValue` で落ちます

---

実行ログ:

```console
~/src/ThrustAsyncProgram$ nvidia-smi --query-gpu=name --format=csv
name
NVIDIA GeForce RTX 4070
~/src/ThrustAsyncProgram$ cmake --version
cmake version 3.30.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).
~/src/ThrustAsyncProgram$ nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2024 NVIDIA Corporation
Built on Thu_Sep_12_02:18:05_PDT_2024
Cuda compilation tools, release 12.6, V12.6.77
Build cuda_12.6.r12.6/compiler.34841621_0
~/src/ThrustAsyncProgram$ g++ --version
g++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

~/src/ThrustAsyncProgram$ cat /etc/os-release
PRETTY_NAME="Ubuntu 24.04.1 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04.1 LTS (Noble Numbat)"
VERSION_CODENAME=noble
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=noble
LOGO=ubuntu-logo
~/src/ThrustAsyncProgram$ ninja --version
1.11.1
~/src/ThrustAsyncProgram$ cmake --preset linux-x64-release
Preset CMake variables:

  CMAKE_BUILD_TYPE="Release"
  CMAKE_CXX_COMPILER="g++"
  CMAKE_INSTALL_PREFIX:PATH="/home/user/src/ThrustAsyncProgram/install/linux-x64-release"

-- The CXX compiler identification is GNU 13.3.0
-- The CUDA compiler identification is NVIDIA 12.6.77
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/local/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting CUDA compiler ABI info
-- Detecting CUDA compiler ABI info - done
-- Check for working CUDA compiler: /usr/local/cuda/bin/nvcc - skipped
-- Detecting CUDA compile features
-- Detecting CUDA compile features - done
-- Found CUDAToolkit: /usr/local/cuda/targets/x86_64-linux/include (found suitable version "12.6.77", minimum required is "12")
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
CMake Deprecation Warning at thrust/CMakeLists.txt:9 (cmake_policy):
  The OLD behavior for policy CMP0104 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.


-- Found libcudacxx: /home/user/src/ThrustAsyncProgram/thrust/dependencies/libcudacxx/lib/cmake/libcudacxx/libcudacxx-config.cmake (found suitable version "1.8.1.0", minimum required is "1.8.0")
-- Found Thrust: /home/user/src/ThrustAsyncProgram/thrust/thrust/cmake/thrust-config.cmake (found version "2.2.0.0")
-- Found CUB: /home/user/src/ThrustAsyncProgram/thrust/dependencies/cub/cub/cmake/cub-config.cmake (found suitable version "2.2.0.0", minimum required is "2.2.0.0")
-- Configuring done (3.3s)
-- Generating done (0.0s)
-- Build files have been written to: /home/user/src/ThrustAsyncProgram/build/linux-x64-release
~/src/ThrustAsyncProgram$ cmake --build build/linux-x64-release
[5/5] Linking CXX executable my_program
~/src/ThrustAsyncProgram$ build/linux-x64-release/my_program
Success!
```
